### PR TITLE
Rename CLI pipe show to display

### DIFF
--- a/src/controller_pipe.cli
+++ b/src/controller_pipe.cli
@@ -5,7 +5,7 @@ CLICON_MODE="|controller_pipe";
    except <arg:string>, pipe_grep_fn("-v", "arg");
    tail, pipe_tail_fn();
    count, pipe_wc_fn("-l");
-   show {
+   display {
      xml, pipe_showas_fn("xml", false);
      curly, pipe_showas_fn("text", true);
      json, pipe_showas_fn("json", false);

--- a/test/test-cli-edit-commit-push.sh
+++ b/test/test-cli-edit-commit-push.sh
@@ -174,10 +174,10 @@ new "CLI: Commit"
 expectpart "$($clixon_cli -1 -f $CFG -m configure commit)" 0 ""
 
 new "CLI: Check controller services configuration"
-expectpart "$($clixon_cli -1 -f $CFG show configuration \| show cli)" 0 "^set services test cli_test" "^set services test cli_test parameter x" "^set services test cli_test parameter x value 1.2.3.4"
+expectpart "$($clixon_cli -1 -f $CFG show configuration \| display cli)" 0 "^set services test cli_test" "^set services test cli_test parameter x" "^set services test cli_test parameter x value 1.2.3.4"
 
 new "CLI: Check controller devices configuration"
-expectpart "$($clixon_cli -1 -f $CFG show configuration \| show xml)" 0 "<name>y</name>" "<value>1.2.3.4</value>"
+expectpart "$($clixon_cli -1 -f $CFG show configuration \| display xml)" 0 "<name>y</name>" "<value>1.2.3.4</value>"
 
 new "Verify containers"
 

--- a/test/test-cli-edit-multiple.sh
+++ b/test/test-cli-edit-multiple.sh
@@ -1,5 +1,5 @@
 # Controller test script for cli set/delete multiple, using glob '*'
-# XXX | show not work OK for cli
+# XXX | display not work OK for cli
 
 set -u
 
@@ -79,7 +79,7 @@ delete("Delete a configuration item") {
 quit("Quit"), cli_quit();
 show("Show a particular state of the system"), @datamodelshow, cli_show_auto_mode("candidate", "xml", true, false);{
     @datamodelshow, cli_show_auto_devs("candidate", "xml", false, false);
-    # old syntax, but left here because | show cli  does not work properly
+    # old syntax, but left here because | display cli  does not work properly
     cli, cli_show_auto_mode("candidate", "cli", true, false, "report-all", "set ");{
          @datamodelshow, cli_show_auto_devs("candidate", "cli", false, false, "report-all", "set ");
     }


### PR DESCRIPTION
Otherwise we will end up with CLI commands like "show config | show cli" which is a bit confusing.