### PR TITLE
docker-compose test for clixon-controller

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ FROM debian:bookworm-slim
 MAINTAINER Kristofer Hallin <kristofer@sunet.se>
 
 RUN apt update
-RUN apt install -y emacs-nox git make gcc bison libnghttp2-dev libssl-dev flex python3 python3-pip sudo
+RUN apt install -y emacs-nox git make gcc bison libnghttp2-dev libssl-dev flex python3 python3-pip sudo sshpass
 
 RUN mkdir /clixon
 WORKDIR /clixon
@@ -63,7 +63,7 @@ WORKDIR /clixon/clixon-pyapi
 RUN python3 setup.py install
 RUN cp clixon_server.py /usr/local/bin/
 
-USER clicon
+#USER clicon
 RUN pip3 install -r requirements.txt --break-system-packages
 
 USER root

--- a/docker/README.md
+++ b/docker/README.md
@@ -51,3 +51,55 @@ Or using restconf using curl on exposed port 8082:
 You may also do `make push` if you want to push the image, but you may then consider changing the image name (in the Makefile:s).
 
 (You may have to login for push with sudo docker login -u <username>)
+
+# Docker Compose Environment
+
+A docker-compose.yml is provided that will launch two instances of the Clixon openconfig example (r1 & r2), then the
+controller.
+
+The Controller's entrypoint is overridden to create a keypair and install the public key on each of r1 and r2 such that
+the controller can perform passwordless authentication as user "noc".
+
+The docker-compose.yml assumes that the clixon/openconfig and clixon/controller images have alreay been built per
+instructions found elsewhere, or published to Dockerhub; that is, `docker-compose build` will not build them.
+
+## Startup
+
+```
+  $ docker-compose up
+```
+
+Once the containers are running, the controller CLI can be run and devices added:
+
+```
+  $ docker-compose up -d
+  Creating network "docker_default" with the default driver
+  Creating r2 ... done
+  Creating r1 ... done
+  Creating controller ... done
+  vagrant@ubuntu2004:~/clixon-controller/docker$ docker exec -it controller clixon_cli -f /usr/local/etc/controller.xml
+  nobody@d18823315355> configure
+  nobody@d18823315355[/]# set devices device r1 addr r1
+  nobody@d18823315355[/]# set devices device r1 user noc
+  nobody@d18823315355[/]# set devices device r1 enabled true
+  nobody@d18823315355[/]# set devices device r1 conn-type NETCONF_SSH
+  nobody@d18823315355[/]# set devices device r1 yang-config BIND
+  nobody@d18823315355[/]# set devices device r2 addr r2
+  nobody@d18823315355[/]# set devices device r2 user noc
+  nobody@d18823315355[/]# set devices device r2 enabled true
+  nobody@d18823315355[/]# set devices device r2 conn-type NETCONF_SSH
+  nobody@d18823315355[/]# set devices device r2 yang-config BIND
+  nobody@d18823315355[/]# commit local
+  nobody@d18823315355[/]# exit
+  nobody@d18823315355> show devices
+  Name                    State      Time                   Logmsg
+  =======================================================================================
+  r1                      CLOSED
+  r2                      CLOSED
+  nobody@d18823315355> connection open
+  nobody@d18823315355> show devices
+  Name                    State      Time                   Logmsg
+  =======================================================================================
+  r1                      OPEN       2023-08-17T14:56:34
+  r2                      OPEN       2023-08-17T14:56:34
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "2.2"
+services:
+  controller:
+    container_name: controller
+    image: clixon/controller:latest
+    ports:
+      - "8082:80"
+    depends_on:
+      - r1
+      - r2
+    volumes:
+      - ./prepare-ssh.sh:/prepare-ssh.sh
+    entrypoint: ["/bin/bash", "/prepare-ssh.sh"]
+  r1:
+    container_name: r1
+    image: clixon/openconfig:latest
+  r2:
+    container_name: r2
+    image: clixon/openconfig:latest
+

--- a/docker/prepare-ssh.sh
+++ b/docker/prepare-ssh.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Generate SSH key
+ssh-keygen -q -t rsa -f /root/.ssh/id_rsa -N ""
+
+# Copy SSH key to r1 and r2
+sshpass -p noc ssh-copy-id -o StrictHostKeyChecking=accept-new noc@r1
+sshpass -p noc ssh-copy-id -o StrictHostKeyChecking=accept-new noc@r2
+
+# Execute the original entrypoint
+# exec "$@"
+/usr/local/bin/startsystem.sh
+


### PR DESCRIPTION
- add sshpass to clixon-controller dockerfile to easily add ssh keys to managed devices
- update docker README.md with usage
- add docker-compose that creates two openconfig example containers and controller container, then creates controller ssh keypair and installs public key on example containers
- fix time2str calls expecting a pointer to struct timeval