### PR TITLE
install: Respect user/group from configure

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -125,8 +125,8 @@ install: $(CLISPECS) $(PLUGINS) $(APPNAME).xml autocli.xml
 	install -m 0644 $(INSTALLFLAGS) $(BE_PLUGIN) $(DESTDIR)$(libdir)/$(APPNAME)/backend
 	install -m 0644 $(INSTALLFLAGS) $(CLI_PLUGIN) $(DESTDIR)$(libdir)/$(APPNAME)/cli
 	install -d -m 0755 $(DESTDIR)$(datarootdir)/clixon/controller/mounts # See YANG_SCHEMA_MOUNT_DIR
-	install -d -m 0755 -g clicon $(DESTDIR)$(localstatedir)/run # for pidfiles
-	install -d -m 0755 -o clicon -g clicon $(DESTDIR)$(datarootdir)/clixon/controller/modules/
+	install -d -m 0755 -g @CLICON_GROUP@ $(DESTDIR)$(localstatedir)/run # for pidfiles
+	install -d -m 0755 -o @CLICON_USER@ -g @CLICON_GROUP@ $(DESTDIR)$(datarootdir)/clixon/controller/modules/
 
 uninstall:
 	rm -f $(DESTDIR)$(sysconfdir)/clixon/$(APPNAME).xml


### PR DESCRIPTION
Respect user and group defined during configure instead of forcing it to
be clicon
